### PR TITLE
fix(RhinoCore): try to find the dlls from assembly directory

### DIFF
--- a/src/RhinoCore.cs
+++ b/src/RhinoCore.cs
@@ -84,11 +84,13 @@ namespace Rhino.Testing
                 Path.Combine(Configs.Current.RhinoSystemDir, "netfx"),
 #endif
                 Configs.Current.RhinoSystemDir,
-                typeof(RhinoCore).Assembly.Location,
+                Configs.Current.SettingsDir,
+                Path.GetDirectoryName(typeof(RhinoCore).Assembly.Location),
                 Path.Combine(Configs.Current.RhinoSystemDir, @"Plug-ins\Grasshopper"),
             })
             {
                 string file = Path.Combine(path, name + ".dll");
+                file = File.Exists(file) ? file : Path.ChangeExtension(file, ".rhp");
                 if (File.Exists(file))
                 {
                     TestContext.WriteLine($"Loading assembly from file {file}");


### PR DESCRIPTION
This PR fixed two items:

1. fix loading dlls from the assembly directory
2. support loading rhp file
cc @fraguada 