### PR TITLE
Enabled auto-merge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
+      - uses: kenhowardpdx/auto-merge-action@v1
+
       - name: Install dotnet 8.0
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.