### PR TITLE
Actions can chain now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,17 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: kenhowardpdx/auto-merge-action@v1
+      - name: Get token
+        id: my-app
+        uses: getsentry/action-github-app-token@v3
+        with:
+          app_id: ${{ secrets.MERGE_DOWN_APP_ID }}
+          private_key: ${{ secrets.MERGE_DOWN_APP_PRIVATE_KEY }}
+
+      - name: Enable Auto-Merge
+        uses: kenhowardpdx/auto-merge-action@v1
+        with:
+          token: ${{ steps.my-app.outputs.token }}
 
       - name: Install dotnet 8.0
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.