### PR TITLE
Bump Rhino.Inside for experimental Mac support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [9.0.5-beta] - 2025-12-16
+- Bump Rhino.Inside to 9.0.10-beta for experimental Mac support.
+- Bump RhinoCommon and Grasshopper version to 9.0.25350.305-wip
+
 ## [9.0.4-beta] - 2025-05-13
 - Added support for loading Grasshopper 2
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RhinoTestingVersion>9.0.4</RhinoTestingVersion>
-    <RhinoInsideVersion>9.0.2-beta</RhinoInsideVersion>
-    <RhinoAPIVersion>9.0.25051.305-wip</RhinoAPIVersion>
+    <RhinoTestingVersion>9.0.5</RhinoTestingVersion>
+    <RhinoInsideVersion>9.0.10-beta</RhinoInsideVersion>
+    <RhinoAPIVersion>9.0.25350.305-wip</RhinoAPIVersion>
     <SourceDir>$(MSBuildThisFileDirectory)src\</SourceDir>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <CopyrightYear>2025</CopyrightYear>


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.

- [x] Increased Version Number?
- [x] Updated CHANGELOG.md?